### PR TITLE
Make import.sh more robust supporting more environments

### DIFF
--- a/import.sh
+++ b/import.sh
@@ -1,8 +1,15 @@
 #!/bin/bash
 
-BASE="/tmp/demo/bin/"
+### Tested with OSX brew installation arangodb v3.4.7
+BASE=""
+ARANGOSH_PARAM="--server.password ''"
+
+### Older versions
+#BASE="/tmp/demo/bin/"
+#SHPARAM="-s"
+
 ARANGOIMP="${BASE}arangoimp"
-ARANGOSH="${BASE}arangosh"
+ARANGOSH="${BASE}arangosh ${ARANGOSH_PARAM}"
 
 while [ 0 -lt "$#" ];  do
   case "$1" in
@@ -27,67 +34,67 @@ done
 
 echo "Importing 10000 fake users into 'users'"
 echo "======================================="
-(echo 'db._drop("users");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("users");' | eval $ARANGOSH) || exit 1
 $ARANGOIMP --server.password "" --file RandomUsers/names_10000.json --collection=users --create-collection=true --type=json || exit 1
-(echo 'db.users.ensureHashIndex("name.first"); db.users.ensureHashIndex("name.last");' | $ARANGOSH -s) || exit 1
-(echo 'db.users.ensureHashIndex("contact.address.city"); db.users.ensureHashIndex("contact.address.zip");' | $ARANGOSH -s) || exit 1
+(echo 'db.users.ensureHashIndex("name.first"); db.users.ensureHashIndex("name.last");' | eval $ARANGOSH) || exit 1
+(echo 'db.users.ensureHashIndex("contact.address.city"); db.users.ensureHashIndex("contact.address.zip");' | eval $ARANGOSH) || exit 1
 echo
 echo
 
 echo "Importing cities into 'cities'"
 echo "=============================="
-(echo 'db._drop("cities");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("cities");' | eval $ARANGOSH) || exit 1
 $ARANGOIMP --server.password "" --file Cities/GeoLiteCity.csv --collection=cities --create-collection=true --type=csv || exit 1
-(echo 'db.users.ensureGeoIndex("latitude", "longitude");' | $ARANGOSH -s) || exit 1
-(echo 'db.users.ensureHashIndex("city");' | $ARANGOSH -s) || exit 1
+(echo 'db.users.ensureGeoIndex("latitude", "longitude");' | eval $ARANGOSH) || exit 1
+(echo 'db.users.ensureHashIndex("city");' | eval $ARANGOSH) || exit 1
 echo
 echo
 
 echo "Importing countries into 'countries'"
 echo "===================================="
-(echo 'db._drop("countries");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("countries");' | eval $ARANGOSH) || exit 1
 $ARANGOIMP --server.password "" --file Countries/countries.csv --collection=countries --create-collection=true --type=csv || exit 1
-(echo 'db.users.ensureHashIndex("name");' | $ARANGOSH -s) || exit 1
+(echo 'db.users.ensureHashIndex("name");' | eval $ARANGOSH) || exit 1
 echo
 echo
 
 echo "Importing regions into 'regions'"
 echo "================================"
-(echo 'db._drop("regions");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("regions");' | eval $ARANGOSH) || exit 1
 $ARANGOIMP --server.password "" --file Regions/regions.csv --collection=regions --create-collection=true --type=csv || exit 1
-(echo 'db.users.ensureHashIndex("name");' | $ARANGOSH -s) || exit 1
+(echo 'db.users.ensureHashIndex("name");' | eval $ARANGOSH) || exit 1
 echo
 echo
 
 echo "Importing McDonalds France into 'mcdonalds'"
 echo "==========================================="
-(echo 'db._drop("mcdonalds");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("mcdonalds");' | eval $ARANGOSH) || exit 1
 $ARANGOIMP --server.password "" --file McDonalds/france.csv --collection=mcdonalds --create-collection=true --type=csv || exit 1
-(echo 'db.users.ensureGeoIndex("lat", "long");' | $ARANGOSH -s) || exit 1
+(echo 'db.users.ensureGeoIndex("lat", "long");' | eval $ARANGOSH) || exit 1
 echo
 echo
 
 echo "Importing German Counties into 'bezirke'"
 echo "========================================"
-(echo 'db._drop("bezirke");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("bezirke");' | eval $ARANGOSH) || exit 1
 $ARANGOIMP --server.password "" --file Bezirke/bezirke.csv --collection=bezirke --create-collection=true --type=csv || exit 1
-(echo 'db.users.ensureGeoIndex("lat", "long");' | $ARANGOSH -s) || exit 1
-(echo 'db.users.ensureHashIndex("FULL_NAME_RO");' | $ARANGOSH -s) || exit 1
+(echo 'db.users.ensureGeoIndex("lat", "long");' | eval $ARANGOSH) || exit 1
+(echo 'db.users.ensureHashIndex("FULL_NAME_RO");' | eval $ARANGOSH) || exit 1
 echo
 echo
 
 echo "Importing Airports into 'airports'"
 echo "=================================="
-(echo 'db._drop("airports");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("airports");' | eval $ARANGOSH) || exit 1
 $ARANGOIMP --server.password "" --file Airports/airports.csv --collection=airports --create-collection=true --type=csv || exit 1
-(echo 'db.users.ensureGeoIndex("latitude_deg", "longitude_deg");' | $ARANGOSH -s) || exit 1
-(echo 'db.users.ensureHashIndex("name");' | $ARANGOSH -s) || exit 1
+(echo 'db.users.ensureGeoIndex("latitude_deg", "longitude_deg");' | eval $ARANGOSH) || exit 1
+(echo 'db.users.ensureHashIndex("name");' | eval $ARANGOSH) || exit 1
 echo
 echo
 
 echo "Importing NerdPursuit into 'nerds'"
 echo "=================================="
-(echo 'db._drop("nerds");' | $ARANGOSH -s) || exit 1
+(echo 'db._drop("nerds");' | eval $ARANGOSH) || exit 1
 (cd NerdPursuit && ./nerd_pursuit_compress.sh)
 (cd NerdPursuit && $ARANGOIMP --server.password "" --file nerd_pursuit_compressed.json --collection=nerds --create-collection=true --type=json) || exit 1
 echo


### PR DESCRIPTION
With this change proposal I am making import.sh more flexible to support more environments and arangosh parameters to be configurable not hardcoded to -s.

Running the current master version results to an error message probably because of an obsoleted option -s

```bash
$ arangosh -s
Error while processing command-line options for arangosh:
  unknown option '--s'
```
This proposed solution is tested and works well for me with arangodb v3.4.7 osx Mojave 10.14.5
and arangodb installed via `brew install arangodb`

